### PR TITLE
Fix: .from() did not attach a type when a BetterArray is given

### DIFF
--- a/src/Arrays/better_array.ts
+++ b/src/Arrays/better_array.ts
@@ -7,7 +7,7 @@ export default class BetterArray<T> extends Array {
      * @param input The array-like object
      * @returns BetterArray of type T
      */
-    static from<T>(input: T[]): BetterArray<T> {
+    static from<T>(input: T[] | BetterArray<T>): BetterArray<T> {
         return new BetterArray(input)
     }
     


### PR DESCRIPTION
Fixed an issue where passing a BetterArray in the static `.from()` method results in not attaching a type to the new array

Behaviour Before Fix:
```ts
const betterArray = new BetterArray([1, 2, 3 ,4])
// newCoolerArray --> BetterArray<any> -- expected --> BetterArray<number>
const newCoolerArray = BetterArray.from(betterArray)
```

Workaround to solve the issue shown above:
```ts
const newCoolerArray: BetterArray<number> = BetterArray.from(betterArray)
```

Behaviour After Fix:
```ts
const betterArray = new BetterArray([1, 2, 3 ,4])
// newCoolerArray --> BetterArray<number>
const newCoolerArray = BetterArray.from(betterArray)
```